### PR TITLE
issue/109

### DIFF
--- a/plugins/reading.js
+++ b/plugins/reading.js
@@ -32,8 +32,10 @@ exports.register = function (server, options, next) {
 
     // Get the number of readings for each reading day.
     server.method('getReadingStats', function (scope, next) {
-        let isAdmin = scope.find(elt => elt == 'admin');
-
+        let isAdmin = false; 
+        if(scope !== undefined){
+           isAdmin = scope.find(elt => elt == 'admin'); 
+        }
         let query = ReadingDay.query()
             .select('readingDay.date')
             .count('reading.id')
@@ -96,7 +98,10 @@ exports.register = function (server, options, next) {
             path: '/readings/meta',
             config: {
                 description: 'Readings metadata',
-                auth: 'jwt',
+                auth:{ 
+                    strategy: 'jwt',
+                    mode: 'try'
+                },
                 pre: [
                     {assign: 'readingStats', method: 'getReadingStats(auth.credentials.scope)'}
                 ]


### PR DESCRIPTION
We assume in the general case that the user is not an admin.                    
If the scope isn't empty, meaning the user is an admin, then we can display the extra dates.
We also changed the authentication mode to 'try'  (line 103).